### PR TITLE
Do not display draft blocks in Add Block screen

### DIFF
--- a/assets/js/builder/gridblock/filter.js
+++ b/assets/js/builder/gridblock/filter.js
@@ -39,6 +39,8 @@ BOLDGRID.EDITOR.GRIDBLOCK = BOLDGRID.EDITOR.GRIDBLOCK || {};
 
 					if ( 'library' !== this.type ) {
 						self.removeInvalidGridblocks( this, gridblockId );
+					} else if ( 'publish' !== this.status ) {
+						self.removeGridblock( gridblockId );
 					}
 				} );
 

--- a/includes/media/class-boldgrid-editor-layout.php
+++ b/includes/media/class-boldgrid-editor-layout.php
@@ -72,6 +72,7 @@ class Boldgrid_Layout extends Boldgrid_Editor_Media_Tab {
 
 				// Save Markup
 				$row_html = self::outer_HTML( $potential_row );
+
 				$rows[] = self::format_gridblock_data( $post, $row_html );
 			}
 		}
@@ -85,13 +86,13 @@ class Boldgrid_Layout extends Boldgrid_Editor_Media_Tab {
 		$shortcode_translated_html = wpautop( $html );
 
 		return array (
-			'template' => $post->post_title,
-			'html' => $shortcode_translated_html,
+			'template'     => $post->post_title,
+			'html'         => $shortcode_translated_html,
 			'preview_html' => self::run_shortcodes( $shortcode_translated_html ),
-			'type' => 'bg_block' === $post->post_type ? 'library' : 'saved',
-			'status' => ! empty( $post ) && $post->post_status ? $post->post_status : 'publish',
-			'is_post' => ! empty( $post ) ? 'post' === $post->post_type : false,
-			'str_length' => strlen( $shortcode_translated_html ),
+			'type'         => 'bg_block' === $post->post_type ? 'library' : 'saved',
+			'status'       => ! empty( $post ) && $post->post_status ? $post->post_status : 'publish',
+			'is_post'      => ! empty( $post ) ? 'post' === $post->post_type : false,
+			'str_length'   => strlen( $shortcode_translated_html ),
 		);
 	}
 

--- a/includes/media/class-boldgrid-editor-layout.php
+++ b/includes/media/class-boldgrid-editor-layout.php
@@ -72,7 +72,6 @@ class Boldgrid_Layout extends Boldgrid_Editor_Media_Tab {
 
 				// Save Markup
 				$row_html = self::outer_HTML( $potential_row );
-
 				$rows[] = self::format_gridblock_data( $post, $row_html );
 			}
 		}
@@ -90,8 +89,9 @@ class Boldgrid_Layout extends Boldgrid_Editor_Media_Tab {
 			'html' => $shortcode_translated_html,
 			'preview_html' => self::run_shortcodes( $shortcode_translated_html ),
 			'type' => 'bg_block' === $post->post_type ? 'library' : 'saved',
+			'status' => ! empty( $post ) && $post->post_status ? $post->post_status : 'publish',
 			'is_post' => ! empty( $post ) ? 'post' === $post->post_type : false,
-			'str_length' => strlen( $shortcode_translated_html )
+			'str_length' => strlen( $shortcode_translated_html ),
 		);
 	}
 

--- a/post-and-page-builder.php
+++ b/post-and-page-builder.php
@@ -3,7 +3,7 @@
  * Plugin Name: Post and Page Builder
  * Plugin URI: https://www.boldgrid.com/boldgrid-editor/?utm_source=ppb-wp-repo&utm_medium=plugin-uri&utm_campaign=ppb
  * Description: Customized drag and drop editing for posts and pages. The Post and Page Builder adds functionality to the existing TinyMCE Editor to give you easier control over your content.
- * Version: 1.21.2
+ * Version: 1.21.2-issue403
  * Author: BoldGrid <support@boldgrid.com>
  * Author URI: https://www.boldgrid.com/?utm_source=ppb-wp-repo&utm_medium=author-uri&utm_campaign=ppb
  * Text Domain: boldgrid-editor


### PR DESCRIPTION
resolves #403

# Testing Instructions #
1. Install the attached Post and Page Builder Zip File or use this [one-click-link](https://www.boldgrid.com/central/cloud-wordpress/try?plugins=https://github.com/BoldGrid/post-and-page-builder/files/9568614/post-and-page-builder-1.21.2-issue403.zip)

[post-and-page-builder-1.21.2-issue403.zip](https://github.com/BoldGrid/post-and-page-builder/files/9568614/post-and-page-builder-1.21.2-issue403.zip)


2. Create a new block ( WP Dashboard > Post and Page Builder > Add New Block ) and save as draft. DO NOT PUBLISH.

3. Go to a a page or post, and click the 'Add Block' button. 

4. Select 'Block Library' from the dropdown filter at the top of the screen.

5. Ensure that the block you saved as a Draft is not shown.

6. Return to you draft block, and publish it.

7. Repeat steps 3-4 and then ensure that the block you published is now shown.
