### PR TITLE
Issue 401 - Remove 'Used Blocks' option from Add Block screen

### DIFF
--- a/assets/json/builder.json
+++ b/assets/json/builder.json
@@ -131,10 +131,6 @@
             {
                 "slug": "library",
                 "title": "Block Library"
-            },
-            {
-                "slug": "saved",
-                "title": "Used Blocks"
             }
         ]
     },


### PR DESCRIPTION
ISSUE: Resolves #401 

PROJECT: [PPB 1.23.1](https://github.com/orgs/BoldGrid/projects/14/views/11)

# Remove 'Used Blocks' option from Add Block screen #

## Test Files ##

[post-and-page-builder.zip](https://github.com/BoldGrid/post-and-page-builder/files/11179760/post-and-page-builder.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Edit a page / post or create a new page / post
3. Click the 'Add Block' button to open the Add Block screen
4. Click the dropdown labeled 'Type'
5. Ensure that the 'Used Blocks' option is no longer present in the list.