### PR TITLE
Adding a new row with a heading removes the column code #547

### DIFF
--- a/assets/js/builder/validation/section.js
+++ b/assets/js/builder/validation/section.js
@@ -92,6 +92,52 @@ BOLDGRID.EDITOR.VALIDATION = BOLDGRID.EDITOR.VALIDATION || {};
 	};
 
 	/**
+	 * Find all content elements that are not in columns and wrap them.
+	 * 
+	 * @since 1.25.1
+	 */
+	let wrapUncolumnedElements = function() {
+		var wrap,
+			group = [],
+			contentSelector = [
+				'p',
+				'h1',
+				'h2',
+				'h3',
+				'h4',
+				'h5',
+				'h6',
+				'h7'
+			].join( ',' );
+
+		wrap = function() {
+			$( group ).each( ( _, el ) => {
+				$( el ).wrap( '<div class="col-lg-12 col-md-12 col-xs-12 col-sm-12"></div>' );
+				$( el ).removeAttr( 'class' );
+				let contents = $( el ).find( 'p' ).text();
+				$( el ).html( contents );
+			} );
+			group = [];
+		};
+
+		self.$context.find( 'div.row > *' ).each( function() {
+			var $this = $( this );
+			// Do not wrap next page marker or tinyMCE bookmarks.
+			if (
+				$this.is( contentSelector ) &&
+				! $this.find( '.mce-wp-nextpage' ).length &&
+				! $this.find( '.mce_SELRES_start' ).length
+			) {
+				group.push( this );
+			} else {
+				wrap();
+			}
+		} );
+
+		wrap();
+	};
+
+	/**
 	 * Update content within context.
 	 *
 	 * @since 1.2.7
@@ -105,6 +151,9 @@ BOLDGRID.EDITOR.VALIDATION = BOLDGRID.EDITOR.VALIDATION || {};
 
 		// Wrap sibling content elements not in rows, into rows.
 		wrapElementGroup();
+
+		// Wrap content elements not in columns, into columns.
+		wrapUncolumnedElements();
 
 		// Add Class boldgrid-section to all parent of containers.
 		addSectionClass();


### PR DESCRIPTION
ISSUE: Resolves #547 
PROJECT: [#14](https://github.com/orgs/BoldGrid/projects/14/views/11)

# Adding a new row with a heading removes the column code #

## Test Files ##

[post-and-page-builder-1.25.1-issue-547.zip](https://github.com/BoldGrid/post-and-page-builder/files/13031230/post-and-page-builder-1.25.1-issue-547.zip)

## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Edit or create a post / page
3. Add some content if none already exists
4. Add a new empty row using the row popup controls.
5. Using the selector at the top left of the tinyMCE frame select a font format ( Heading 1, Heading 2, etc ).
6. Type something with the font.
7. Inspect the elements to ensure they have the correct structure (  Row > Column > H1 ):
```
<div class="row" style="padding-top: 0px;">
    <div class="col-lg-12 col-md-12 col-xs-12 col-sm-12">
        <h1>Heading 1</h1>
    </div>
</div>
```

