### PR TITLE
Fix PPB Warnings emitted when loading Yoast SEO

### DIFF
--- a/components/class-boldgrid-components-shortcode.php
+++ b/components/class-boldgrid-components-shortcode.php
@@ -179,7 +179,7 @@ class Boldgrid_Components_Shortcode {
 		} );
 		foreach ( $this->config['components'] as $component ) {
 			// This has been changed to 'edit_posts' to allow Authors and Contributors to use the editor.
-			if ( current_user_can( 'edit_posts' ) ) {
+			if ( current_user_can( 'edit_posts' ) && isset( $component['name'] ) ) {
 				add_action( 'wp_ajax_boldgrid_component_' . $component['name'], function () use ( $component ) {
 					$this->ajax_shortcode( $component, 'content' );
 				} );


### PR DESCRIPTION
ISSUE: Resolves #536 

PROJECT: [PPB Issues](https://github.com/orgs/BoldGrid/projects/14/views/11)

# Fix PPB Warnings emitted when loading Yoast SEO #

## Test Files ##

[post-and-page-builder-1.26.2-issue-536.zip](https://github.com/BoldGrid/post-and-page-builder/files/14067559/post-and-page-builder-1.26.2-issue-536.zip)
[post-and-page-builder-premium-1.1.4-issue-536.zip](https://github.com/BoldGrid/post-and-page-builder/files/14067622/post-and-page-builder-premium-1.1.4-issue-536.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Enable Yoast SEO and navigate to the Yoast Settings page.
3. Check the sitemaps by clicking on the 'View the XML sitemap' button shown below
![image](https://github.com/BoldGrid/post-and-page-builder/assets/49331357/6130e677-e6c3-4123-9ac8-71224789bed9)
4. Ensure no errors are shown
