### PR TITLE
Fix multi-sliders not changing min/max/step slider options on unit change

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,7 +1158,7 @@
 
 "@boldgrid/controls@https://github.com/BoldGrid/controls#ppb-dev":
   version "0.13.1"
-  resolved "https://github.com/BoldGrid/controls#afc93f52d8678910370c148b037c509d881b9a7d"
+  resolved "https://github.com/BoldGrid/controls#b91e5fd6d0746cfaed7abeeeda3a0d94f1a9fc8e"
   dependencies:
     "@boldgrid/components" "^2.16.25"
     Buttons "https://github.com/BoldGrid/Buttons"


### PR DESCRIPTION
ISSUE: Resolves #608 

# Fix multi-sliders not changing min/max/step slider options on unit change #

## Test Files ##

[post-and-page-builder-1.27.4-issue-608.zip](https://github.com/user-attachments/files/18083719/post-and-page-builder-1.27.4-issue-608.zip)

## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Open a page and add a block if needed for content
3. Open the Row popover and click Advanced Controls
4. Click on Border Radius - see how the sliders for PX and EM go to a max value of 50, with 1px steps. 
5. Set a pixel value on the slider.
6. Change the unit to EM, and ensure that the PX unit is converted, and that the slider max value is now 5, with 1px steps. 
