### PR TITLE
fix table height issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 	},
 	"dependencies": {
 		"@babel/preset-react": "^7.22.3",
-		"@boldgrid/components": "^2.16.34",
+		"@boldgrid/components": "^2.16.35",
 		"@boldgrid/controls": "https://github.com/BoldGrid/controls#ppb-dev",
 		"@boldgrid/fourpan": "^1.1.1",
 		"@wordpress/components": "^25.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,10 +1151,10 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@boldgrid/components@^2.16.2", "@boldgrid/components@^2.16.25", "@boldgrid/components@^2.16.34":
-  version "2.16.34"
-  resolved "https://registry.yarnpkg.com/@boldgrid/components/-/components-2.16.34.tgz#14a30378cfdc75bb0694c4b6d3e3419701ed711b"
-  integrity sha512-oE0mQa1ZgIk2jSVN0ZPsdH6Yt81/j+94EdAvzh39NWAwzrnZTfWmF7bTHgxPeD1peWboaKKS8/Dqr5agTty4mw==
+"@boldgrid/components@^2.16.2", "@boldgrid/components@^2.16.25", "@boldgrid/components@^2.16.35":
+  version "2.16.35"
+  resolved "https://registry.yarnpkg.com/@boldgrid/components/-/components-2.16.35.tgz#77091f8f98a627db56e22ce88dd3254bfafdc0d4"
+  integrity sha512-B4NVQRBSvLmjr1P4KFSNRjNpABzYzd9LW1/o9/RSxXWVVgrafulMPYgBYgU6LFTtC4g+d9+xkIBYFQU/gxt+bA==
 
 "@boldgrid/controls@https://github.com/BoldGrid/controls#ppb-dev":
   version "0.13.1"


### PR DESCRIPTION
ISSUE: Resolves #632 

# Fixed table height causes sections to overlap #

## Test Files ##

[post-and-page-builder-1.27.5-issue-632.zip](https://github.com/user-attachments/files/18413890/post-and-page-builder-1.27.5-issue-632.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Create a post with three sections.
3. Add content to the top and bottom sections.
4. Add a table to the center sections
5. Adjust the height of the table by dragging the tables resize handles.
6. Set the table to use responsive views on tablet and phone.
7. Save the post, and view the post either on a phone, or a resized browser window.
8. Ensure that the table doesn't overlap the content on the sections above or below as it does in the screenshot for this issue.