### PR TITLE
Issue 609

### DIFF
--- a/assets/js/builder/controls/generic/table-borders.js
+++ b/assets/js/builder/controls/generic/table-borders.js
@@ -230,8 +230,6 @@ import template from '../../../../../includes/template/customize/table-borders.h
 			$colorControl.on( 'change', function() {
 				var $this = $( this );
 
-				console.log( $this.val() );
-
 				// If $this.val() is a single digit or 'neutral' color, then convert it to a color variable.
 				if ( $this.val().length === 1 || $this.val() === 'neutral' ) {
 					$this.val( `var(--color-${$this.val()})` );

--- a/assets/js/builder/controls/generic/table-borders.js
+++ b/assets/js/builder/controls/generic/table-borders.js
@@ -230,6 +230,13 @@ import template from '../../../../../includes/template/customize/table-borders.h
 			$colorControl.on( 'change', function() {
 				var $this = $( this );
 
+				console.log( $this.val() );
+
+				// If $this.val() is a single digit or 'neutral' color, then convert it to a color variable.
+				if ( $this.val().length === 1 || $this.val() === 'neutral' ) {
+					$this.val( `var(--color-${$this.val()})` );
+				}
+
 				self.applyBorderStyle( $this.val(), options, 'color' );
 			} );
 		},


### PR DESCRIPTION
ISSUE: Resolves #609 

# Set table borders as a color-variable instead of hex #

## Test Files ##

[post-and-page-builder-1.27.5-issue-609.zip](https://github.com/user-attachments/files/18414267/post-and-page-builder-1.27.5-issue-609.zip)


## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Install Crio.
3. Create a page or post with a table.
4. Set the table border color to a theme color.
5. Change that theme color in the customizer to a different color, or change pallets to a different palette
6. Ensure that the table border color changes as well.