### PR TITLE
create new escaping function for htags

### DIFF
--- a/includes/Widget/HeadingWidget.php
+++ b/includes/Widget/HeadingWidget.php
@@ -78,6 +78,19 @@ class HeadingWidget extends \WP_Widget {
 		$this->text_string = $text;
 	}
 
+	public function escape_htags( $htag ) {
+		$allowed_tags = array(
+			'h1' => array(),
+			'h2' => array(),
+			'h3' => array(),
+			'h4' => array(),
+			'h5' => array(),
+			'h6' => array(),
+		);
+
+		return array_key_exists( $htag, $allowed_tags ) ? $htag : 'h1';
+	}
+
 	/**
 	 * Update a widget with a new configuration.
 	 *
@@ -104,10 +117,11 @@ class HeadingWidget extends \WP_Widget {
 	public function widget( $args, $instance )  {
 		$alignment = ! empty( $instance['bgc_title_alignment'] ) ? $instance['bgc_title_alignment'] : 'center';
 		$htag      = ! empty( $instance['bgc_heading_type'] ) ? $instance['bgc_heading_type'] : 'h1';
+		$htag_safe = $this->escape_htags( $htag );
 
-		$styles = 'font-weight: inherit; text-transform: inherit; line-height: inherit; font-family: inherit; font-style: inherit; font-size: inherit; color: inherit; text-align:' . $alignment . ';';
+		$styles_escaped = 'font-weight: inherit; text-transform: inherit; line-height: inherit; font-family: inherit; font-style: inherit; font-size: inherit; color: inherit; text-align:' . esc_attr( $alignment ) . ';';
 
-		echo '<' . $htag . ' class="bgc_page_title" style="' . $styles . '">' . $this->text_string . '</' . $htag . '>';
+		echo '<' . $htag_safe . ' class="bgc_page_title" style="' . $styles_escaped . '">' . esc_html( $this->text_string ) . '</' . $htag_safe . '>';
 	}
 
 

--- a/includes/Widget/PageTitle.php
+++ b/includes/Widget/PageTitle.php
@@ -57,6 +57,9 @@ class PageTitle extends HeadingWidget {
 		} else {
 			$title = '[ Page Title ]';
 		}
+		if ( is_admin() ) {
+			$title = '[ Page Title ]';
+		}
 
 		parent::__construct(
 			'boldgrid_component_page_title',

--- a/includes/Widget/SiteDescription.php
+++ b/includes/Widget/SiteDescription.php
@@ -48,10 +48,11 @@ class SiteDescription extends HeadingWidget {
 	public function widget( $args, $instance )  {
 		$alignment = ! empty( $instance['bgc_title_alignment'] ) ? $instance['bgc_title_alignment'] : 'center';
 		$htag      = ! empty( $instance['bgc_heading_type'] ) ? $instance['bgc_heading_type'] : 'h1';
+		$htag_safe = $this->escape_htags( $htag );
 
-		$styles = 'font-weight: inherit; text-transform: inherit; line-height: inherit; font-family: inherit; font-style: inherit; font-size: inherit; color: inherit; text-align:' . $alignment . ';';
+		$styles_escaped = 'font-weight: inherit; text-transform: inherit; line-height: inherit; font-family: inherit; font-style: inherit; font-size: inherit; color: inherit; text-align:' . esc_attr( $alignment ) . ';';
 
-		echo '<' . $htag . ' class="bgc_site_description" style="' . $styles . '">' . $this->text_string . '</' . $htag . '>';
+		echo '<' . $htag_safe . ' class="bgc_site_description" style="' . $styles_escaped . '">' . esc_html( $this->text_string ) . '</' . $htag_safe . '>';
 	}
 
 	/**

--- a/includes/Widget/SiteTitle.php
+++ b/includes/Widget/SiteTitle.php
@@ -172,13 +172,14 @@ class SiteTitle extends HeadingWidget {
 	 * @param  array $instance Widget instance arguments.
 	 */
 	public function widget( $args, $instance )  {
-		$alignment    = ! empty( $instance['bgc_title_alignment'] ) ? $instance['bgc_title_alignment'] : 'center';
-		$htag         = ! empty( $instance['bgc_heading_type'] ) ? $instance['bgc_heading_type'] : 'h1';
-		$link_to_home = isset( $instance['bgc_link_to_home'] ) && '0' === $instance['bgc_link_to_home'] ? false : true;
-		$styles = 'text-decoration: inherit; font-weight: inherit; text-transform: inherit; line-height: inherit; font-family: inherit; font-style: inherit; font-size: inherit; color: inherit; text-align:' . $alignment . ';';
-		$home_link_markup   = '<a href ="' . get_home_url() . '" style="' . $styles . '">' . $this->text_string . '</a>';
-		$site_title         = $link_to_home ? $home_link_markup : $this->text_string;
+		$alignment               = ! empty( $instance['bgc_title_alignment'] ) ? $instance['bgc_title_alignment'] : 'center';
+		$htag                    = ! empty( $instance['bgc_heading_type'] ) ? $instance['bgc_heading_type'] : 'h1';
+		$htag_safe               = $this->escape_htags( $htag );
+		$link_to_home            = isset( $instance['bgc_link_to_home'] ) && '0' === $instance['bgc_link_to_home'] ? false : true;
+		$styles_escaped          = 'text-decoration: inherit; font-weight: inherit; text-transform: inherit; line-height: inherit; font-family: inherit; font-style: inherit; font-size: inherit; color: inherit; text-align:' . esc_attr( $alignment ) . ';';
+		$home_link_markup_safe   = '<a href ="' . esc_url( get_home_url() ) . '" style="' . $styles_escaped . '">' . esc_html( $this->text_string ) . '</a>';
+		$site_title_safe         = $link_to_home ? $home_link_markup_safe : esc_html( $this->text_string );
 
-		echo '<' . $htag . ' class="bgc_site_title ' . ( $link_to_home ? 'site-title' : '' ) . '" style="' . $styles . '">' . $site_title . '</' . $htag . '>';
+		echo '<' . $htag_safe . ' class="bgc_site_title ' . ( $link_to_home ? 'site-title' : '' ) . '" style="' . $styles_escaped . '">' . $site_title_safe . '</' . $htag_safe . '>';
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "boldgrid-editor",
-	"version": "1.27.5",
+	"version": "1.27.6",
 	"description": "Post and Page Builder is a standalone plugin which adds functionality to the existing TinyMCE Editor.",
 	"main": "assets/js/editor.js",
 	"scripts": {

--- a/post-and-page-builder.php
+++ b/post-and-page-builder.php
@@ -3,7 +3,7 @@
  * Plugin Name: Post and Page Builder
  * Plugin URI: https://www.boldgrid.com/boldgrid-editor/?utm_source=ppb-wp-repo&utm_medium=plugin-uri&utm_campaign=ppb
  * Description: Customized drag and drop editing for posts and pages. The Post and Page Builder adds functionality to the existing TinyMCE Editor to give you easier control over your content.
- * Version: 1.27.5
+ * Version: 1.27.6
  * Author: BoldGrid <support@boldgrid.com>
  * Author URI: https://www.boldgrid.com/?utm_source=ppb-wp-repo&utm_medium=author-uri&utm_campaign=ppb
  * Text Domain: boldgrid-editor

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: boldgrid, page builder, drag and drop, tinymce, editor, landing page
 Requires at least: 4.7
 Tested up to: 6.7
 Requires PHP: 5.4
-Stable tag: 1.27.5
+Stable tag: 1.27.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -134,6 +134,9 @@ WordPress Editor.
 
 == Changelog ==
 
+= 1.27.6 =
+* Security Update: Resolved a security vulnerability reported by PatchStack [#635](https://github.com/BoldGrid/post-and-page-builder/issues/635)
+
 = 1.27.5 =
 * Bug Fix: Table Borders do not change with palette [#609](https://github.com/BoldGrid/post-and-page-builder/issues/609)
 * Bug Fix: Fixed height tables break in responsive views. [#632](https://github.com/BoldGrid/post-and-page-builder/issues/632)


### PR DESCRIPTION
ISSUE: Resolves #635

# Add Custom Escaping for the $htag variable #

## Test Files ##

[post-and-page-builder-1.27.6-rc.1.zip](https://github.com/user-attachments/files/18493360/post-and-page-builder-1.27.6-rc.1.zip)

## NOTES TO TESTER ##
### Please leave comments regarding issues found in testing directly on the issue linked above, not the Pull Request. This helps ease the process of reviewing the testing of multiple PRs in a given project from the project view. ###
### Please remember to move this item from 'Needs Review' to either 'In Progress' or 'Awaiting Release' depending on the results of your testing ###

## Testing Instructions ##

1. Install the test zip files linked above.
2. Follow the replication steps in #635 
3. Ensure that the alert window is not shown.